### PR TITLE
fix: remaining time getters

### DIFF
--- a/contracts/examples/Escrow.sol
+++ b/contracts/examples/Escrow.sol
@@ -152,9 +152,9 @@ contract Escrow is IArbitrable, IEvidence {
     function remainingTimeToReclaim(uint256 _txID) public view returns (uint256) {
         TX storage transaction = txs[_txID];
 
-        if (transaction.status != Status.Initial) revert("Transaction is not in Initial state.");
+        require(transaction.status == Status.Initial, "Transaction is not in Initial state.");
         return
-            (transaction.createdAt + transaction.reclamationPeriod - block.timestamp) > transaction.reclamationPeriod
+            (block.timestamp - transaction.createdAt) > transaction.reclamationPeriod
                 ? 0
                 : (transaction.createdAt + transaction.reclamationPeriod - block.timestamp);
     }
@@ -162,10 +162,9 @@ contract Escrow is IArbitrable, IEvidence {
     function remainingTimeToDepositArbitrationFee(uint256 _txID) public view returns (uint256) {
         TX storage transaction = txs[_txID];
 
-        if (transaction.status != Status.Reclaimed) revert("Transaction is not in Reclaimed state.");
+        require(transaction.status == Status.Reclaimed, "Transaction is not in Reclaimed state.");
         return
-            (transaction.reclaimedAt + transaction.arbitrationFeeDepositPeriod - block.timestamp) >
-                transaction.arbitrationFeeDepositPeriod
+            (block.timestamp - transaction.reclaimedAt) > transaction.arbitrationFeeDepositPeriod
                 ? 0
                 : (transaction.reclaimedAt + transaction.arbitrationFeeDepositPeriod - block.timestamp);
     }

--- a/contracts/examples/SimpleEscrow.sol
+++ b/contracts/examples/SimpleEscrow.sol
@@ -94,17 +94,17 @@ contract SimpleEscrow is IArbitrable {
     }
 
     function remainingTimeToReclaim() public view returns (uint256) {
-        if (status != Status.Initial) revert("Transaction is not in Initial state.");
+        require(status == Status.Initial, "Transaction is not in Initial state.");
         return
-            (createdAt + reclamationPeriod - block.timestamp) > reclamationPeriod
+            (block.timestamp - createdAt) > reclamationPeriod
                 ? 0
                 : (createdAt + reclamationPeriod - block.timestamp);
     }
 
     function remainingTimeToDepositArbitrationFee() public view returns (uint256) {
-        if (status != Status.Reclaimed) revert("Transaction is not in Reclaimed state.");
+        require(status == Status.Reclaimed, "Transaction is not in Reclaimed state.");
         return
-            (reclaimedAt + arbitrationFeeDepositPeriod - block.timestamp) > arbitrationFeeDepositPeriod
+            (block.timestamp - reclaimedAt) > arbitrationFeeDepositPeriod
                 ? 0
                 : (reclaimedAt + arbitrationFeeDepositPeriod - block.timestamp);
     }


### PR DESCRIPTION
I was using the SimpleEscrow contract as starting point for the arbitrable libraries tutorial and found this error. It's just a sample contract but we are showing it in the docs https://developer.kleros.io/en/latest/implementing-an-arbitrable.html.