### PR TITLE
create check for arbitrationFeeDeposit expiration

### DIFF
--- a/contracts/examples/SimpleEscrow.sol
+++ b/contracts/examples/SimpleEscrow.sol
@@ -78,6 +78,7 @@ contract SimpleEscrow is IArbitrable {
 
     function depositArbitrationFeeForPayee() public payable {
         require(status == Status.Reclaimed, "Transaction is not in Reclaimed state.");
+        require(block.timestamp - reclaimedAt < arbitrationFeeDepositPeriod, "Arbitration fee deposit time expired");
         arbitrator.createDispute{value: msg.value}(numberOfRulingOptions, "");
         status = Status.Disputed;
     }

--- a/contracts/examples/SimpleEscrow.sol
+++ b/contracts/examples/SimpleEscrow.sol
@@ -78,7 +78,7 @@ contract SimpleEscrow is IArbitrable {
 
     function depositArbitrationFeeForPayee() public payable {
         require(status == Status.Reclaimed, "Transaction is not in Reclaimed state.");
-        require(block.timestamp - reclaimedAt < arbitrationFeeDepositPeriod, "Arbitration fee deposit time expired");
+        require(block.timestamp - reclaimedAt <= arbitrationFeeDepositPeriod, "Arbitration fee deposit time expired");
         arbitrator.createDispute{value: msg.value}(numberOfRulingOptions, "");
         status = Status.Disputed;
     }


### PR DESCRIPTION
Shouldn't there be a check for if the arbitrationFeeDepositPeriod time has elapsed in the depositArbitrationFeeForPayee() function? Otherwise, the payee can deposit an arbitration fee at any time and create a dispute, even if the period has elapsed and the payer has already reclaimed their funds.